### PR TITLE
Warmtepomp occured twice in the menu and keys. 

### DIFF
--- a/config/locales/nl.menu.yml
+++ b/config/locales/nl.menu.yml
@@ -52,7 +52,7 @@ nl:
   centraal_grijs: centraal grijs
   lokaal_groene_opwek: lokaal groene opwek
   wko: wko
-  warmtepomp: warmtepomp
+  warmtepomp_groen: warmtepomp
   restwarmte: restwarmte
   lokaal_biogas: lokaal biogas
   collector: collector
@@ -113,7 +113,7 @@ nl:
   internationaal_profielen: internationaal profielen
   specifieke_applicaties: specifieke applicaties
   elektrisch_vervoer: elektrisch vervoer
-  warmtepomp: warmtepomp
+  warmtepomp_vraag: warmtepomp
   demand_response: demand response
   markten_en_business_cases: markten en business cases
   bestaande_marktrollen: bestaande marktrollen

--- a/data/menu_structure.yml
+++ b/data/menu_structure.yml
@@ -54,7 +54,7 @@ systeemcomponenten:
       - centraal_grijs
     lokaal_groene_opwek:
       - wko
-      - warmtepomp
+      - warmtepomp_groen
       - restwarmte
       - lokaal_biogas
       - collector
@@ -116,7 +116,7 @@ systeemcomponenten:
     - internationaal_profielen
   specifieke_applicaties:
     - elektrisch_vervoer
-    - warmtepomp
+    - warmtepomp_vraag
     - demand_response
 markten_en_business_cases:
   - bestaande_marktrollen

--- a/data/models/cegoia.yml
+++ b/data/models/cegoia.yml
@@ -20,7 +20,7 @@ properties:
   - tabellen
   - grafieken
   - wko
-  - warmtepomp
+  - warmtepomp_groen
   - restwarmte
   - lokaal_biogas
   - collector
@@ -41,7 +41,7 @@ properties:
   - per_jaar
   - huishoudelijk_apparaat_profielen
   - wijk_profielen
-  - warmtepomp
+  - warmtepomp_vraag
   - bestaande_marktrollen
   - nieuwe_marktrollen
   - stakeholders

--- a/data/models/cegrid.yml
+++ b/data/models/cegrid.yml
@@ -20,7 +20,7 @@ properties:
   - centraal_wind
   - pv_zonnepark
   - centraal_grijs
-  - warmtepomp
+  - warmtepomp_groen
   - pv
   - lokaal_wind
   - ruimteverwarming
@@ -42,7 +42,7 @@ properties:
   - nationaal_profielen
   - internationaal_profielen
   - elektrisch_vervoer
-  - warmtepomp
+  - warmtepomp_vraag
   - demand_response
   - bestaande_marktrollen
   - gereed_model

--- a/data/models/chess.yml
+++ b/data/models/chess.yml
@@ -30,7 +30,7 @@ properties:
   - pv_zonnepark
   - centraal_grijs
   - wko
-  - warmtepomp
+  - warmtepomp_groen
   - restwarmte
   - collector
   - pv
@@ -56,7 +56,7 @@ properties:
   - aansluiting
   - wijk_profielen
   - stad_profielen
-  - warmtepomp
+  - warmtepomp_vraag
   - demand_response
   - framework
   - gereed_model

--- a/data/models/dido.yml
+++ b/data/models/dido.yml
@@ -35,7 +35,7 @@ properties:
   - pv_zonnepark
   - centraal_grijs
   - wko
-  - warmtepomp
+  - warmtepomp_groen
   - restwarmte
   - lokaal_biogas
   - collector
@@ -77,7 +77,7 @@ properties:
   - regio_profielen
   - nationaal_profielen
   - elektrisch_vervoer
-  - warmtepomp
+  - warmtepomp_vraag
   - demand_response
   - bestaande_marktrollen
   - nieuwe_marktrollen

--- a/data/models/dssm.yml
+++ b/data/models/dssm.yml
@@ -26,7 +26,7 @@ properties:
   - pv_zonnepark
   - centraal_grijs
   - wko
-  - warmtepomp
+  - warmtepomp_groen
   - lokaal_biogas
   - pv
   - lokaal_wind
@@ -52,7 +52,7 @@ properties:
   - aansluiting
   - nationaal_profielen
   - elektrisch_vervoer
-  - warmtepomp
+  - warmtepomp_vraag
   - demand_response
   - stakeholders
   - simulatie_prijsvorming

--- a/data/models/etm.yml
+++ b/data/models/etm.yml
@@ -33,7 +33,7 @@ properties:
   - centraal_wind
   - pv_zonnepark
   - wko
-  - warmtepomp
+  - warmtepomp_groen
   - restwarmte
   - lokaal_biogas
   - collector
@@ -55,6 +55,7 @@ properties:
   - hoge_temperatur
   - net_inlaadbaar_opbouwbaar_in_het_model
   - elektrisch_vervoer_mobiliteit
+  - warmtepomp_vraag
   - demand_response
   - elektriciteits_opslag
   - gas_opslag

--- a/data/models/gebiedsmodel.yml
+++ b/data/models/gebiedsmodel.yml
@@ -25,7 +25,7 @@ properties:
   - pv_zonnepark
   - centraal_grijs
   - wko
-  - warmtepomp
+  - warmtepomp_groen
   - restwarmte
   - lokaal_biogas
   - collector
@@ -53,7 +53,7 @@ properties:
   - stad_profielen
   - regio_profielen
   - elektrisch_vervoer
-  - warmtepomp
+  - warmtepomp_vraag
   - gereed_model
   - 1_mandag
   - 1_tot_10_mandagen

--- a/data/models/itsf.yml
+++ b/data/models/itsf.yml
@@ -24,7 +24,7 @@ properties:
   - pv_zonnepark
   - centraal_grijs
   - wko
-  - warmtepomp
+  - warmtepomp_groen
   - pv
   - lokaal_wind
   - wkk
@@ -49,7 +49,7 @@ properties:
   - stad_profielen
   - regio_profielen
   - elektrisch_vervoer
-  - warmtepomp
+  - warmtepomp_vraag
   - demand_response
   - bestaande_marktrollen
   - nieuwe_marktrollen

--- a/data/models/mkbins.yml
+++ b/data/models/mkbins.yml
@@ -21,7 +21,7 @@ properties:
   - centraal_wind
   - pv_zonnepark
   - centraal_grijs
-  - warmtepomp
+  - warmtepomp_groen
   - pv
   - lokaal_wind
   - ruimteverwarming
@@ -40,7 +40,7 @@ properties:
   - stad_profielen
   - regio_profielen
   - elektrisch_vervoer
-  - warmtepomp
+  - warmtepomp_vraag
   - demand_response
   - bestaande_marktrollen
   - gereed_model

--- a/data/models/opera.yml
+++ b/data/models/opera.yml
@@ -27,7 +27,7 @@ properties:
   - pv_zonnepark
   - centraal_grijs
   - wko
-  - warmtepomp
+  - warmtepomp_groen
   - restwarmte
   - lokaal_biogas
   - collector
@@ -60,7 +60,7 @@ properties:
   - regio_profielen
   - nationaal_profielen
   - elektrisch_vervoer
-  - warmtepomp
+  - warmtepomp_vraag
   - demand_response
   - overheidsmaatregelen_instelbaar
   - framework

--- a/data/models/pico.yml
+++ b/data/models/pico.yml
@@ -10,7 +10,7 @@ properties:
   - geografisch
   - centraal_wind
   - wko
-  - warmtepomp
+  - warmtepomp_groen
   - restwarmte
   - pv
   - lokaal_wind
@@ -29,7 +29,7 @@ properties:
   - stad_profielen
   - regio_profielen
   - nationaal_profielen
-  - warmtepomp
+  - warmtepomp_vraag
   - framework
   - 0_tot_halve_mandag
   - 0_uur

--- a/data/models/powerfys.yml
+++ b/data/models/powerfys.yml
@@ -25,7 +25,7 @@ properties:
   - centraal_wind
   - pv_zonnepark
   - centraal_grijs
-  - warmtepomp
+  - warmtepomp_groen
   - restwarmte
   - pv
   - lokaal_wind
@@ -56,7 +56,7 @@ properties:
   - nationaal_profielen
   - internationaal_profielen
   - elektrisch_vervoer
-  - warmtepomp
+  - warmtepomp_vraag
   - demand_response
   - bestaande_marktrollen
   - simulatie_prijsvorming

--- a/data/models/vesta.yml
+++ b/data/models/vesta.yml
@@ -24,7 +24,7 @@ properties:
   - biogas_opwek
   - centraal_grijs
   - wko
-  - warmtepomp
+  - warmtepomp_groen
   - restwarmte
   - lokaal_biogas
   - collector
@@ -40,7 +40,7 @@ properties:
   - stad_profielen
   - regio_profielen
   - nationaal_profielen
-  - warmtepomp
+  - warmtepomp_vraag
   - overheidsmaatregelen_instelbaar
   - framework
   - gereed_model

--- a/data/models/warmtevraagprofielen.yml
+++ b/data/models/warmtevraagprofielen.yml
@@ -30,7 +30,7 @@ properties:
   - biogas_opwek
   - centraal_wind
   - centraal_grijs
-  - warmtepomp
+  - warmtepomp_groen
   - lokaal_biogas
   - pv
   - lokaal_wind
@@ -64,7 +64,7 @@ properties:
   - nationaal_profielen
   - internationaal_profielen
   - elektrisch_vervoer
-  - warmtepomp
+  - warmtepomp_vraag
   - demand_response
   - gereed_model
   - 0_tot_halve_mandag


### PR DESCRIPTION
Renamed two occurences to warmtepomp_groen and warmtepomp_vraag in the menu and the model files

Fixes https://github.com/etrm/keuzehulp/issues/24