### PR TITLE
Bump the capistrano ruby version to 2.3.1

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -6,7 +6,7 @@ set :repo_url, 'git@github.com:quintel/keuzehulp.git'
 
 # Set up rbenv
 set :rbenv_type, :user
-set :rbenv_ruby, '2.1.1'
+set :rbenv_ruby, '2.3.1'
 set :rbenv_prefix, "RBENV_ROOT=#{fetch(:rbenv_path)} RBENV_VERSION=#{fetch(:rbenv_ruby)} #{fetch(:rbenv_path)}/bin/rbenv exec"
 set :rbenv_map_bins, %w{rake gem bundle ruby rails}
 


### PR DESCRIPTION
Fixes: #36 

I was wondering if this could also be done as:

```diff
diff --git a/config/deploy.rb b/config/deploy.rb
index 10c0bdb..9775179 100644
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -6,7 +6,7 @@ set :repo_url, 'git@github.com:quintel/keuzehulp.git'
 
 # Set up rbenv
 set :rbenv_type, :user
-set :rbenv_ruby, '2.3.1'
+set :rbenv_ruby, `cat .ruby-version`.strip
 set :rbenv_prefix, "RBENV_ROOT=#{fetch(:rbenv_path)} RBENV_VERSION=#{fetch(:rbenv_ruby)} #{fetch(:rbenv_path)}/bin/rbenv exec"
 set :rbenv_map_bins, %w{rake gem bundle ruby rails}
```